### PR TITLE
在 lab0 的文档中添加 #![feature(llvm_asm)]

### DIFF
--- a/docs/lab-0/guide/part-7.md
+++ b/docs/lab-0/guide/part-7.md
@@ -86,6 +86,10 @@ boot_stack_top:
 //! - `#![feature(global_asm)]`  
 //!   内嵌整个汇编文件
 #![feature(global_asm)]
+//!
+//! - `#![feature(llvm_asm)]`
+//!   声明需要使用 llvm_asm 宏特性
+#![feature(llvm_asm)]
 
 // 汇编编写的程序入口，具体见该文件
 global_asm!(include_str!("entry.asm"));

--- a/docs/lab-0/guide/part-8.md
+++ b/docs/lab-0/guide/part-8.md
@@ -57,6 +57,10 @@ PMP1: 0x0000000000000000-0xffffffffffffffff (A,R,W,X)
 //! - `#![feature(global_asm)]`
 //!   内嵌整个汇编文件
 #![feature(global_asm)]
+//!
+//! - `#![feature(llvm_asm)]`
+//!   声明需要使用 llvm_asm 宏特性
+#![feature(llvm_asm)]
 
 // 汇编编写的程序入口，具体见该文件
 global_asm!(include_str!("entry.asm"));

--- a/docs/lab-0/guide/part-9.md
+++ b/docs/lab-0/guide/part-9.md
@@ -247,6 +247,10 @@ extern "C" fn abort() -> ! {
 //!   内嵌整个汇编文件
 #![feature(global_asm)]
 //!
+//! - `#![feature(llvm_asm)]`
+//!   声明需要使用 llvm_asm 宏特性
+#![feature(llvm_asm)]
+//!
 //! - `#![feature(panic_info_message)]`  
 //!   panic! 时，获取其中的信息并打印
 #![feature(panic_info_message)]


### PR DESCRIPTION
如果按照lab0的教程一步步实现的话，会出现编译错误：

```
error[E0658]: use of unstable library feature 'llvm_asm': prefer using the new asm! syntax instead
  --> src/main.rs:38:9
   |
38 |         llvm_asm!("ecall"
   |         ^^^^^^^^
   |
   = note: see issue #70173 <https://github.com/rust-lang/rust/issues/70173> for more information
   = help: add `#![feature(llvm_asm)]` to the crate attributes to enable

error: aborting due to previous error
```
可以参考这个issue：[https://github.com/rust-lang/rust/issues/70173](https://github.com/rust-lang/rust/issues/70173)

这个问题在最后 os 文件夹的代码集合中已经被修复，可能是lab0的教程遗漏了