### PR TITLE
Add quality of life dbg macro

### DIFF
--- a/os/src/console.rs
+++ b/os/src/console.rs
@@ -65,3 +65,46 @@ macro_rules! println {
         $crate::console::print(format_args!(concat!($fmt, "\n") $(, $($arg)+)?));
     }
 }
+
+/// Quality of life debug macro
+/// Copy pasted from Rust's standard library
+macro_rules! dbg {
+    () => {
+        println!("[{}:{}]", file!(), line!());
+    };
+    ($val:expr) => {
+        match $val {
+            tmp => {
+                println!("[{}:{}] {} = {:#?}",
+                    file!(), line!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    // Recursively evaluate argument
+    ($val:expr,) => { $crate::dbg!($val) };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::dbg!($val)),+,)
+    };
+}
+
+/// Dbg macro, but print in hex
+macro_rules! dbgx {
+    () => {
+        println!("[{}:{}]", file!(), line!());
+    };
+    ($val:expr) => {
+        match $val {
+            tmp => {
+                // Print in hex
+                println!("[{}:{}] {} = {:#x?}",
+                    file!(), line!(), stringify!($val), &tmp);
+                tmp
+            }
+        }
+    };
+    ($val:expr,) => { dbgx!($val) };
+    ($($val:expr),+ $(,)?) => {
+        ($(dbgx!($val)),+,)
+    };
+}

--- a/os/src/console.rs
+++ b/os/src/console.rs
@@ -68,6 +68,8 @@ macro_rules! println {
 
 /// Quality of life debug macro
 /// Copy pasted from Rust's standard library
+#[macro_export]
+#[allow(unused_macros)]
 macro_rules! dbg {
     () => {
         println!("[{}:{}]", file!(), line!());
@@ -89,6 +91,8 @@ macro_rules! dbg {
 }
 
 /// Dbg macro, but print in hex
+#[macro_export]
+#[allow(unused_macros)]
 macro_rules! dbgx {
     () => {
         println!("[{}:{}]", file!(), line!());

--- a/os/src/interrupt/context.rs
+++ b/os/src/interrupt/context.rs
@@ -13,7 +13,7 @@ use riscv::register::sstatus::{self, Sstatus, SPP::*};
 /// ### `#[repr(C)]` 属性
 /// 要求 struct 按照 C 语言的规则进行内存分布，否则 Rust 可能按照其他规则进行内存排布
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Context {
     /// 通用寄存器
     pub x: [usize; 32],
@@ -30,23 +30,6 @@ pub struct Context {
 impl Default for Context {
     fn default() -> Self {
         unsafe { zeroed() }
-    }
-}
-
-/// 格式化输出
-///
-/// # Example
-///
-/// ```rust
-/// println!("{:x?}", Context);   // {:x?} 表示用十六进制打印其中的数值
-/// ```
-impl fmt::Debug for Context {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Context")
-            .field("registers", &self.x)
-            .field("sstatus", &self.sstatus)
-            .field("sepc", &self.sepc)
-            .finish()
     }
 }
 

--- a/os/src/interrupt/context.rs
+++ b/os/src/interrupt/context.rs
@@ -1,6 +1,5 @@
 //! 保存现场所用的 struct [`Context`]
 
-use core::fmt;
 use core::mem::zeroed;
 use riscv::register::sstatus::{self, Sstatus, SPP::*};
 


### PR DESCRIPTION
The `dbg!` macro is a utility that I frequently use whilst developing my own Rust application. Printing out the file name and line number greatly aids pinpointing bugs and distinguishing one debug variable from another. This pull request implements the dbg! macro based on the println! macro provided, and mostly resembles the implementation of Rust's standard library. An alternative version, `dbgx!`, prints values in hex, since in the os context we will be frequently dealing with addresses and binary values.

Putting `dbgx!(&context)` in the `handle_interrupt` function will print out something like this.
```
[src/interrupt/handler.rs:48] &context = Context {
    x: [
        0x0,
        0xffffffffffffffff,
        0x1080000,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0xffffffff8025e720,
        0x0,
        0x0,
        0x0,
        0x107fdb4,
        0x4,
        0x1,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
        0x0,
    ],
    sstatus: Sstatus {
        bits: 0x8000000000046120,
    },
    sepc: 0xfffffffffffffffe,
}
```

Also, debug format for struct `Context` is identical to the one you get by #[derive(Debug)].