### PR TITLE
Improve entry.asm

### DIFF
--- a/os/src/entry.asm
+++ b/os/src/entry.asm
@@ -17,8 +17,8 @@
 # 目前 _start 的功能：将预留的栈空间写入 $sp，然后跳转至 rust_main
 _start:
     # 计算 boot_page_table 的物理页号
-    # la 会通过auipc和符号与pc的偏移得到相对地址。
-    # 这边pc在0x80000000附近，获得是boot_page_table的物理地址。
+    # la 会通过auipc和符号与pc的偏移得到相对地址
+    # 这边pc在0x80000000附近，获得是boot_page_table的物理地址
     la t0, boot_page_table
     srli t0, t0, 12
     # 8 << 60 是 satp 中使用 Sv39 模式的记号

--- a/os/src/entry.asm
+++ b/os/src/entry.asm
@@ -6,6 +6,7 @@
 # 关于 RISC-V 下的汇编语言，可以参考 https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md
 # %hi 表示取 [12,32) 位，%lo 表示取 [0,12) 位
 
+# 加载符号的绝对地址
 .macro la_abs rd, symbol
     lui \rd, %hi(\symbol)
     addi \rd, \rd, %lo(\symbol)
@@ -16,6 +17,8 @@
 # 目前 _start 的功能：将预留的栈空间写入 $sp，然后跳转至 rust_main
 _start:
     # 计算 boot_page_table 的物理页号
+    # la 会通过auipc和符号与pc的偏移得到相对地址。
+    # 这边pc在0x80000000附近，获得是boot_page_table的物理地址。
     la t0, boot_page_table
     srli t0, t0, 12
     # 8 << 60 是 satp 中使用 Sv39 模式的记号
@@ -26,6 +29,7 @@ _start:
     sfence.vma
 
     # 加载栈地址
+    # 这边因为是取绝对地址，获得的是boot_stack_top的虚拟地址
     la_abs sp, boot_stack_top
     # 跳转至 rust_main
     # 这里同时伴随 hart 和 dtb_pa 两个指针的传入（是 OpenSBI 帮我们完成的）

--- a/os/src/entry.asm
+++ b/os/src/entry.asm
@@ -52,14 +52,14 @@ boot_stack_top:
     .align 12
     .global boot_page_table
 boot_page_table:
-    .quad 0
-    .quad 0
+    .8byte 0
+    .8byte 0
     # 第 2 项：0x8000_0000 -> 0x8000_0000，0xcf 表示 VRWXAD 均为 1
-    .quad (0x80000 << 10) | 0xcf
+    .8byte (0x80000 << 10) | 0xcf
     .zero 505 * 8
     # 第 508 项：0xffff_ffff_0000_0000 -> 0x0000_0000，0xcf 表示 VRWXAD 均为 1
-    .quad (0x00000 << 10) | 0xcf
-    .quad 0
+    .8byte (0x00000 << 10) | 0xcf
+    .8byte 0
     # 第 510 项：0xffff_ffff_8000_0000 -> 0x8000_0000，0xcf 表示 VRWXAD 均为 1
-    .quad (0x80000 << 10) | 0xcf
-    .quad 0
+    .8byte (0x80000 << 10) | 0xcf
+    .8byte 0

--- a/os/src/entry.asm
+++ b/os/src/entry.asm
@@ -6,20 +6,14 @@
 # 关于 RISC-V 下的汇编语言，可以参考 https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md
 # %hi 表示取 [12,32) 位，%lo 表示取 [0,12) 位
 
-# 加载符号的绝对地址
-.macro la_abs rd, symbol
-    lui \rd, %hi(\symbol)
-    addi \rd, \rd, %lo(\symbol)
-.endm
-
     .section .text.entry
     .globl _start
 # 目前 _start 的功能：将预留的栈空间写入 $sp，然后跳转至 rust_main
 _start:
-    # 计算 boot_page_table 的物理页号
-    # la 会通过auipc和符号与pc的偏移得到相对地址
-    # 这边pc在0x80000000附近，获得是boot_page_table的物理地址
-    la t0, boot_page_table
+    # 通过线性映射关系计算 boot_page_table 的物理页号
+    lui t0, %hi(boot_page_table)
+    li t1, 0xffffffff00000000
+    sub t0, t0, t1
     srli t0, t0, 12
     # 8 << 60 是 satp 中使用 Sv39 模式的记号
     li t1, (8 << 60)
@@ -28,12 +22,13 @@ _start:
     csrw satp, t0
     sfence.vma
 
-    # 加载栈地址
-    # 这边因为是取绝对地址，获得的是boot_stack_top的虚拟地址
-    la_abs sp, boot_stack_top
+    # 加载栈的虚拟地址
+    lui sp, %hi(boot_stack_top)
+    addi sp, sp, %lo(boot_stack_top)
     # 跳转至 rust_main
     # 这里同时伴随 hart 和 dtb_pa 两个指针的传入（是 OpenSBI 帮我们完成的）
-    la_abs t0, rust_main
+    lui t0, %hi(rust_main)
+    addi t0, t0, %lo(rust_main)
     jr t0
 
     # 回忆：bss 段是 ELF 文件中只记录长度，而全部初始化为 0 的一段内存空间
@@ -52,6 +47,7 @@ boot_stack_top:
     .align 12
     .global boot_page_table
 boot_page_table:
+    # .8byte表示长度为8个字节的整数
     .8byte 0
     .8byte 0
     # 第 2 项：0x8000_0000 -> 0x8000_0000，0xcf 表示 VRWXAD 均为 1


### PR DESCRIPTION
自己看这段汇编的时候有点晕……物理地址和虚拟地址没太区分开。😆
添加了一个宏和一些注释，提升可读性。
.quad一开始以为是4个word，16个byte，结果查手册发现是8个byte。改成.8byte不会引起歧义。