### PR TITLE
对 lab-3 -实现内核重映射 中的一小段的更改

### DIFF
--- a/docs/lab-3/guide/part-4.md
+++ b/docs/lab-3/guide/part-4.md
@@ -294,7 +294,6 @@ impl MemorySet {
 
         // 每个字段在页表中进行映射
         for segment in segments.iter() {
-            // 映射结果保存在 mapped_pairs中
             mapping.map(segment, None)?;
         }
         Ok(MemorySet { mapping, segments })

--- a/docs/lab-3/guide/part-4.md
+++ b/docs/lab-3/guide/part-4.md
@@ -290,15 +290,7 @@ impl MemorySet {
                 flags: Flags::READABLE | Flags::WRITABLE,
             },
         ];
-        let mut mapping = Mapping::new()?;
-        // 准备保存所有新分配的物理页面
-        let mut allocated_pairs = Vec::new();
 
-        // 每个字段在页表中进行映射
-        for segment in segments.iter() {
-            // 同时将新分配的映射关系保存到 allocated_pairs 中
-            mapping.map(segment, None)?;
-        }
         Ok(MemorySet { mapping, segments })
     }
 

--- a/docs/lab-3/guide/part-4.md
+++ b/docs/lab-3/guide/part-4.md
@@ -290,7 +290,13 @@ impl MemorySet {
                 flags: Flags::READABLE | Flags::WRITABLE,
             },
         ];
+        let mut mapping = Mapping::new()?;
 
+        // 每个字段在页表中进行映射
+        for segment in segments.iter() {
+            // 映射结果保存在 mapped_pairs中
+            mapping.map(segment, None)?;
+        }
         Ok(MemorySet { mapping, segments })
     }
 


### PR DESCRIPTION
删除了讲解中  `os/src/memory/mapping/memory_set.rs` 部分容易引起误区的 `allocated_pairs` 代码，
这一段
```rust
        let mut mapping = Mapping::new()?;
        // 准备保存所有新分配的物理页面
        let mut allocated_pairs = Vec::new();

        // 每个字段在页表中进行映射
        for segment in segments.iter() {
            // 同时将新分配的映射关系保存到 allocated_pairs 中
            mapping.map(segment, None)?;
        }
```

如果按照，lab-3 tutorial 中的流程，`memory/mapping/mapping.rs` 中 `pub struct Mapping`  定义了元素 `mapped_pairs: VecDeque<(VirtualPageNumber, FrameTracker)>` 用于保存所有分配的物理页面映射信息，并在map方法中用下面语句
```rust
                self.mapped_pairs.push_back((vpn, frame));
```
进行了映射关系的保存，那么再使用 `allocated_pairs` 保存就暂时没有必要，所以我认为可以将这句话删除并对注释进行修正防止产生误区。

> 或者我认为同样可以使用最终完成的代码中的方法进行映射结果的传递，看各位学长的看法了。