### PR TITLE
全自动化部署 GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,5 +24,5 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: rcore-os/rCore-Tutorial-deploy
-          publish_branch: deploy-test
+          publish_branch: master
           publish_dir: ./_book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - 115-auto-deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node.js
+        uses: actions/setup-node@v2.1.0
+        with:
+          node-version: '12.x'
+      - name: Build GitBook
+        run: |
+          npm install gitbook-cli -g
+          gitbook install
+          gitbook build
+      - name: Push to remote repo
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: rcore-os/rCore-Tutorial-deploy
+          publish_branch: deploy-test
+          publish_dir: ./_book

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - 115-auto-deploy
+      - master
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install node.js
+      - name: Install Node.js
         uses: actions/setup-node@v2.1.0
         with:
           node-version: '12.x'
@@ -26,4 +26,4 @@ jobs:
           external_repository: rcore-os/rCore-Tutorial-deploy
           publish_branch: master
           publish_dir: ./_book
-          commit_message: "[Auto-Deploy] ${{ github.event.head_commit.message }}"
+          commit_message: "[Auto-Deploy] "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: GitHub Pages
 
 on:
   push:
@@ -26,3 +26,4 @@ jobs:
           external_repository: rcore-os/rCore-Tutorial-deploy
           publish_branch: master
           publish_dir: ./_book
+          commit_message: "[Auto-Deploy] ${{ github.event.head_commit.message }}"


### PR DESCRIPTION
在 CI 中加了一个新的部署 Pages 的 workflow，现在一旦 push（非 pull request）到 master，会自动运行部署到 rCore-Tutorial-deploy 仓库，不需要再人工干预。